### PR TITLE
Updated ProgrammerAssertions to support Swift 2.2.

### DIFF
--- a/Assertions/ProgrammerAssertions.swift
+++ b/Assertions/ProgrammerAssertions.swift
@@ -21,37 +21,37 @@ import Foundation
 
 /// drop-in replacements
 
-public func assert(@autoclosure condition: () -> Bool, @autoclosure _ message: () -> String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+public func assert(@autoclosure condition: () -> Bool, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
     Assertions.assertClosure(condition(), message(), file, line)
 }
 
-public func assertionFailure(@autoclosure message: () -> String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+public func assertionFailure(@autoclosure message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
     Assertions.assertionFailureClosure(message(), file, line)
 }
 
-public func precondition(@autoclosure condition: () -> Bool, @autoclosure _ message: () -> String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+public func precondition(@autoclosure condition: () -> Bool, @autoclosure _ message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
     Assertions.preconditionClosure(condition(), message(), file, line)
 }
 
-@noreturn public func preconditionFailure(@autoclosure message: () -> String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+@noreturn public func preconditionFailure(@autoclosure message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
     Assertions.preconditionFailureClosure(message(), file, line)
     runForever()
 }
 
-@noreturn public func fatalError(@autoclosure message: () -> String = "", file: StaticString = __FILE__, line: UInt = __LINE__) {
+@noreturn public func fatalError(@autoclosure message: () -> String = "", file: StaticString = #file, line: UInt = #line) {
     Assertions.fatalErrorClosure(message(), file, line)
     runForever()
 }
 
 /// Stores custom assertions closures, by default it points to Swift functions. But test target can override them.
 public class Assertions {
-
+    
     public static var assertClosure              = swiftAssertClosure
     public static var assertionFailureClosure    = swiftAssertionFailureClosure
     public static var preconditionClosure        = swiftPreconditionClosure
     public static var preconditionFailureClosure = swiftPreconditionFailureClosure
     public static var fatalErrorClosure          = swiftFatalErrorClosure
-
+    
     public static let swiftAssertClosure              = { Swift.assert($0, $1, file: $2, line: $3) }
     public static let swiftAssertionFailureClosure    = { Swift.assertionFailure($0, file: $1, line: $2) }
     public static let swiftPreconditionClosure        = { Swift.precondition($0, $1, file: $2, line: $3) }

--- a/AssertionsTests/XCTestCase+ProgrammerAssertions.swift
+++ b/AssertionsTests/XCTestCase+ProgrammerAssertions.swift
@@ -22,11 +22,11 @@ import XCTest
 private let noReturnFailureWaitTime = 0.1
 
 public extension XCTestCase {
-
+    
     /**
      Expects an `assert` to be called with a false condition.
      If `assert` not called or the assert's condition is true, the test case will fail.
-
+     
      - parameter expectedMessage: The expected message to be asserted to the one passed to the `assert`. If nil, then ignored.
      - parameter file:            The file name that called the method.
      - parameter line:            The line number that called the method.
@@ -34,26 +34,26 @@ public extension XCTestCase {
      */
     public func expectAssert(
         expectedMessage: String? = nil,
-        file: StaticString = __FILE__,
-        line: UInt = __LINE__,
+        file: StaticString = #file,
+        line: UInt = #line,
         testCase: () -> Void
         ) {
-
-            expectAssertionReturnFunction("assert", file: file, line: line, function: { (caller) -> () in
-
-                Assertions.assertClosure = { condition, message, _, _ in
-                    caller(condition, message)
-                }
-
-                }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
-                    Assertions.assertClosure = Assertions.swiftAssertClosure
+        
+        expectAssertionReturnFunction("assert", file: file, line: line, function: { (caller) -> () in
+            
+            Assertions.assertClosure = { condition, message, _, _ in
+                caller(condition, message)
             }
+            
+        }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
+            Assertions.assertClosure = Assertions.swiftAssertClosure
+        }
     }
-
+    
     /**
      Expects an `assertionFailure` to be called.
      If `assertionFailure` not called, the test case will fail.
-
+     
      - parameter expectedMessage: The expected message to be asserted to the one passed to the `assertionFailure`. If nil, then ignored.
      - parameter file:            The file name that called the method.
      - parameter line:            The line number that called the method.
@@ -61,26 +61,26 @@ public extension XCTestCase {
      */
     public func expectAssertionFailure(
         expectedMessage: String? = nil,
-        file: StaticString = __FILE__,
-        line: UInt = __LINE__,
+        file: StaticString = #file,
+        line: UInt = #line,
         testCase: () -> Void
         ) {
-
-            expectAssertionReturnFunction("assertionFailure", file: file, line: line, function: { (caller) -> () in
-
-                Assertions.assertionFailureClosure = { message, _, _ in
-                    caller(false, message)
-                }
-
-                }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
-                    Assertions.assertionFailureClosure = Assertions.swiftAssertionFailureClosure
+        
+        expectAssertionReturnFunction("assertionFailure", file: file, line: line, function: { (caller) -> () in
+            
+            Assertions.assertionFailureClosure = { message, _, _ in
+                caller(false, message)
             }
+            
+        }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
+            Assertions.assertionFailureClosure = Assertions.swiftAssertionFailureClosure
+        }
     }
-
+    
     /**
      Expects an `precondition` to be called with a false condition.
      If `precondition` not called or the precondition's condition is true, the test case will fail.
-
+     
      - parameter expectedMessage: The expected message to be asserted to the one passed to the `precondition`. If nil, then ignored.
      - parameter file:            The file name that called the method.
      - parameter line:            The line number that called the method.
@@ -88,26 +88,26 @@ public extension XCTestCase {
      */
     public func expectPrecondition(
         expectedMessage: String? = nil,
-        file: StaticString = __FILE__,
-        line: UInt = __LINE__,
+        file: StaticString = #file,
+        line: UInt = #line,
         testCase: () -> Void
         ) {
-
-            expectAssertionReturnFunction("precondition", file: file, line: line, function: { (caller) -> () in
-
-                Assertions.preconditionClosure = { condition, message, _, _ in
-                    caller(condition, message)
-                }
-
-                }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
-                    Assertions.preconditionClosure = Assertions.swiftPreconditionClosure
+        
+        expectAssertionReturnFunction("precondition", file: file, line: line, function: { (caller) -> () in
+            
+            Assertions.preconditionClosure = { condition, message, _, _ in
+                caller(condition, message)
             }
+            
+        }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
+            Assertions.preconditionClosure = Assertions.swiftPreconditionClosure
+        }
     }
-
+    
     /**
      Expects an `preconditionFailure` to be called.
      If `preconditionFailure` not called, the test case will fail.
-
+     
      - parameter expectedMessage: The expected message to be asserted to the one passed to the `preconditionFailure`. If nil, then ignored.
      - parameter file:            The file name that called the method.
      - parameter line:            The line number that called the method.
@@ -115,26 +115,26 @@ public extension XCTestCase {
      */
     public func expectPreconditionFailure(
         expectedMessage: String? = nil,
-        file: StaticString = __FILE__,
-        line: UInt = __LINE__,
+        file: StaticString = #file,
+        line: UInt = #line,
         testCase: () -> Void
         ) {
-
-            expectAssertionNoReturnFunction("preconditionFailure", file: file, line: line, function: { (caller) -> () in
-
-                Assertions.preconditionFailureClosure = { message, _, _ in
-                    caller(message)
-                }
-
-                }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
-                    Assertions.preconditionFailureClosure = Assertions.swiftPreconditionFailureClosure
+        
+        expectAssertionNoReturnFunction("preconditionFailure", file: file, line: line, function: { (caller) -> () in
+            
+            Assertions.preconditionFailureClosure = { message, _, _ in
+                caller(message)
             }
+            
+        }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
+            Assertions.preconditionFailureClosure = Assertions.swiftPreconditionFailureClosure
+        }
     }
-
+    
     /**
      Expects an `fatalError` to be called.
      If `fatalError` not called, the test case will fail.
-
+     
      - parameter expectedMessage: The expected message to be asserted to the one passed to the `fatalError`. If nil, then ignored.
      - parameter file:            The file name that called the method.
      - parameter line:            The line number that called the method.
@@ -142,23 +142,23 @@ public extension XCTestCase {
      */
     public func expectFatalError(
         expectedMessage: String? = nil,
-        file: StaticString = __FILE__,
-        line: UInt = __LINE__,
+        file: StaticString = #file,
+        line: UInt = #line,
         testCase: () -> Void) {
-
-            expectAssertionNoReturnFunction("fatalError", file: file, line: line, function: { (caller) -> () in
-
-                Assertions.fatalErrorClosure = { message, _, _ in
-                    caller(message)
-                }
-
-                }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
-                    Assertions.fatalErrorClosure = Assertions.swiftFatalErrorClosure
+        
+        expectAssertionNoReturnFunction("fatalError", file: file, line: line, function: { (caller) -> () in
+            
+            Assertions.fatalErrorClosure = { message, _, _ in
+                caller(message)
             }
+            
+        }, expectedMessage: expectedMessage, testCase: testCase) { () -> () in
+            Assertions.fatalErrorClosure = Assertions.swiftFatalErrorClosure
+        }
     }
-
+    
     // MARK:- Private Methods
-
+    
     private func expectAssertionReturnFunction(
         functionName: String,
         file: StaticString,
@@ -168,39 +168,39 @@ public extension XCTestCase {
         testCase: () -> Void,
         cleanUp: () -> ()
         ) {
-
-            let expectation = expectationWithDescription(functionName + "-Expectation")
-            var assertion: (condition: Bool, message: String)? = nil
-
-            function { (condition, message) -> Void in
-                assertion = (condition, message)
-                expectation.fulfill()
+        
+        let expectation = expectationWithDescription(functionName + "-Expectation")
+        var assertion: (condition: Bool, message: String)? = nil
+        
+        function { (condition, message) -> Void in
+            assertion = (condition, message)
+            expectation.fulfill()
+        }
+        
+        // perform on the same thread since it will return
+        testCase()
+        
+        waitForExpectationsWithTimeout(0) { _ in
+            
+            defer {
+                // clean up
+                cleanUp()
             }
-
-            // perform on the same thread since it will return
-            testCase()
-
-            waitForExpectationsWithTimeout(0) { _ in
-
-                defer {
-                    // clean up
-                    cleanUp()
-                }
-
-                guard let assertion = assertion else {
-                    XCTFail(functionName + " is expected to be called.", file: file.stringValue, line: line)
-                    return
-                }
-
-                XCTAssertFalse(assertion.condition, functionName + " condition expected to be false", file: file.stringValue, line: line)
-
-                if let expectedMessage = expectedMessage {
-                    // assert only if not nil
-                    XCTAssertEqual(assertion.message, expectedMessage, functionName + " called with incorrect message.", file: file.stringValue, line: line)
-                }
+            
+            guard let assertion = assertion else {
+                XCTFail(functionName + " is expected to be called.", file: file, line: line)
+                return
             }
+            
+            XCTAssertFalse(assertion.condition, functionName + " condition expected to be false", file: file, line: line)
+            
+            if let expectedMessage = expectedMessage {
+                // assert only if not nil
+                XCTAssertEqual(assertion.message, expectedMessage, functionName + " called with incorrect message.", file: file, line: line)
+            }
+        }
     }
-
+    
     private func expectAssertionNoReturnFunction(
         functionName: String,
         file: StaticString,
@@ -210,34 +210,34 @@ public extension XCTestCase {
         testCase: () -> Void,
         cleanUp: () -> ()
         ) {
-
-            let expectation = expectationWithDescription(functionName + "-Expectation")
-            var assertionMessage: String? = nil
-
-            function { (message) -> Void in
-                assertionMessage = message
-                expectation.fulfill()
+        
+        let expectation = expectationWithDescription(functionName + "-Expectation")
+        var assertionMessage: String? = nil
+        
+        function { (message) -> Void in
+            assertionMessage = message
+            expectation.fulfill()
+        }
+        
+        // act, perform on separate thead because a call to function runs forever
+        dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), testCase)
+        
+        waitForExpectationsWithTimeout(noReturnFailureWaitTime) { _ in
+            
+            defer {
+                // clean up
+                cleanUp()
             }
-
-            // act, perform on separate thead because a call to function runs forever
-            dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), testCase)
-
-            waitForExpectationsWithTimeout(noReturnFailureWaitTime) { _ in
-
-                defer {
-                    // clean up
-                    cleanUp()
-                }
-
-                guard let assertionMessage = assertionMessage else {
-                    XCTFail(functionName + " is expected to be called.", file: file.stringValue, line: line)
-                    return
-                }
-
-                if let expectedMessage = expectedMessage {
-                    // assert only if not nil
-                    XCTAssertEqual(assertionMessage, expectedMessage, functionName + " called with incorrect message.", file: file.stringValue, line: line)
-                }
+            
+            guard let assertionMessage = assertionMessage else {
+                XCTFail(functionName + " is expected to be called.", file: file, line: line)
+                return
             }
+            
+            if let expectedMessage = expectedMessage {
+                // assert only if not nil
+                XCTAssertEqual(assertionMessage, expectedMessage, functionName + " called with incorrect message.", file: file, line: line)
+            }
+        }
     }
 }


### PR DESCRIPTION
Swift 2.2 changed some syntax slightly.  `__LINE__` is replaced with `#line` and `__FILE__` is replaced with `#file`.  `StaticString`s are now just used directly instead of accessing their `stringValue` property.
